### PR TITLE
Normalize labels before choosing calendar colors

### DIFF
--- a/helpers/colors.py
+++ b/helpers/colors.py
@@ -5,5 +5,14 @@ LABEL_TO_COLOR = {
     # add your own mappings here…
 }
 
-def color_for_label(label):
-    return LABEL_TO_COLOR.get(label, None)
+
+def color_for_label(label: str):
+    """Return the calendar colorId for a label.
+
+    The incoming label is normalised to match the keys in
+    ``LABEL_TO_COLOR``.  If no colour is configured for the label,
+    ``None`` is returned so the default (blue) colour is used.
+    """
+    if not label:
+        return None
+    return LABEL_TO_COLOR.get(label.strip())


### PR DESCRIPTION
## Summary
- normalize event labels before mapping to a Google Calendar color
- document color mapping behavior

## Testing
- `python -m py_compile helpers/colors.py`

------
https://chatgpt.com/codex/tasks/task_e_6897478af970832b8e093e75a88a3035