### PR TITLE
Support @label tagging and color emojis in schedule summaries

### DIFF
--- a/helpers/colors.py
+++ b/helpers/colors.py
@@ -1,14 +1,31 @@
 LABEL_TO_COLOR = {
     "טכנית": "6",      # orange
-    "מבצעים": "11",       # Red
-    "גנק": "3",    # Purple
-    "פיקוד": "8",  # Graphite
-    "סונר": "9",  # blueberry
-    "נשק": "10",  # basil green
-    "מפקד": "7",  # cyan
-    "סגן": "2",  # peacock
-    "צוות": "1",  # lavender
+    "מבצעים": "11",    # Red
+    "גנק": "3",        # Purple
+    "פיקוד": "8",      # Graphite
+    "סונר": "9",       # blueberry
+    "נשק": "10",       # basil green
+    "מפקד": "7",       # cyan
+    "סגן": "2",        # peacock
+    "צוות": "1",       # lavender
 }
+
+COLORID_TO_EMOJI = {
+    "1": "",  # lavender
+    "2": "",  # peacock
+    "3": "",  # purple
+    "6": "",  # orange
+    "7": "",  # cyan
+    "8": "",  # graphite
+    "9": "",  # blueberry
+    "10": "", # basil green
+    "11": "", # red
+}
+
 
 def color_for_label(label):
     return LABEL_TO_COLOR.get(label, None)
+
+
+def emoji_for_color(color_id):
+    return COLORID_TO_EMOJI.get(str(color_id), "")

--- a/helpers/contacts.py
+++ b/helpers/contacts.py
@@ -55,7 +55,8 @@ def load_contacts(path="tag_contacts.xlsx"):
 
     _CONTACTS = df
     _LABEL_EMAILS = grouped
-    _LABELS = sorted([k for k, v in grouped.items() if v])
+    # include all labels even if they have no emails (e.g. "טכנית")
+    _LABELS = sorted(grouped.keys())
     return _LABELS
 
 def emails_for_label(label: str):


### PR DESCRIPTION
## Summary
- keep all labels from contacts, even those without emails (e.g. טכנית)
- leave color ID→emoji mapping empty for custom emoji selection

## Testing
- `python -m py_compile helpers/colors.py helpers/contacts.py telegram_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68984d95cda8832bac99fd812fc26fcd