### PR TITLE
Enable job queue support for python-telegram-bot

### DIFF
--- a/telegram-bot/requirements.txt
+++ b/telegram-bot/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot
+python-telegram-bot[job-queue]
 python-dotenv
 openai
 google-api-python-client


### PR DESCRIPTION
## Summary
- install `python-telegram-bot[job-queue]` to include APScheduler for job queue features

## Testing
- `python -m py_compile telegram-bot/*.py telegram-bot/helpers/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b563d99c90832b8ca02535eb8237eb