### PR TITLE
Add webhook web service entrypoint for Render deployment

### DIFF
--- a/telegram-bot/render_web_service.py
+++ b/telegram-bot/render_web_service.py
@@ -1,0 +1,33 @@
+import os
+
+from telegram_bot import build_application
+
+
+def main() -> None:
+    port = int(os.environ.get("PORT", "8000"))
+    external_url = os.environ.get("RENDER_EXTERNAL_URL")
+    webhook_path = os.environ.get("TELEGRAM_WEBHOOK_PATH", "telegram-webhook").strip()
+
+    if not external_url:
+        raise RuntimeError("RENDER_EXTERNAL_URL environment variable is required")
+
+    webhook_path = webhook_path.lstrip("/") or "telegram-webhook"
+    webhook_url = f"{external_url.rstrip('/')}/{webhook_path}"
+
+    application = build_application()
+
+    print(
+        f"🌐 Starting webhook listener on port {port} "
+        f"with external URL {webhook_url}"
+    )
+
+    application.run_webhook(
+        listen="0.0.0.0",
+        port=port,
+        url_path=webhook_path,
+        webhook_url=webhook_url,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/telegram-bot/requirements.txt
+++ b/telegram-bot/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot[job-queue]
+python-telegram-bot[job-queue,webhooks]
 python-dotenv
 openai
 google-api-python-client


### PR DESCRIPTION
## Summary
- refactor the Telegram bot setup into a reusable build_application helper
- add a webhook-based entrypoint for Render web service deployments
- enable python-telegram-bot webhook extras in requirements

## Testing
- python -m compileall telegram-bot

------
https://chatgpt.com/codex/tasks/task_e_68b9cb5294e4832ba294d3f560c7ca92